### PR TITLE
feat: GlobalExceptionHandler 도입 및 CoreException 기반 예외 표준화

### DIFF
--- a/src/main/java/com/example/bookmanagementsystembo/exception/CoreException.java
+++ b/src/main/java/com/example/bookmanagementsystembo/exception/CoreException.java
@@ -1,0 +1,15 @@
+package com.example.bookmanagementsystembo.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CoreException extends RuntimeException {
+    private final ErrorType errorType;
+    private final Object payload;
+
+    public CoreException(ErrorType errorType, Object payload) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.payload = payload;
+    }
+}

--- a/src/main/java/com/example/bookmanagementsystembo/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookmanagementsystembo/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.bookmanagementsystembo.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "404: 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500: 서버 내부 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "400: 클라이언트 요청 오류입니다."),
+    CONFLICT(HttpStatus.CONFLICT,"409: 요청 충돌 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401: 인증에 실패했습니다.")
+    ;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/bookmanagementsystembo/exception/ErrorResponse.java
+++ b/src/main/java/com/example/bookmanagementsystembo/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.example.bookmanagementsystembo.exception;
+
+public record ErrorResponse(String errorCodeMessage, String message, Object payload) {
+
+    public static ErrorResponse of(String errorCodeMessage, String message, Object payload) {
+        return new ErrorResponse(errorCodeMessage, message, payload);
+    }
+
+    public static ErrorResponse of(String errorCodeMessage, String message) {
+        return new ErrorResponse(errorCodeMessage, message, null);
+    }
+}

--- a/src/main/java/com/example/bookmanagementsystembo/exception/ErrorType.java
+++ b/src/main/java/com/example/bookmanagementsystembo/exception/ErrorType.java
@@ -1,0 +1,23 @@
+package com.example.bookmanagementsystembo.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+    USER_NOT_FOUND(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다.", LogLevel.WARN),
+    USER_ALREADY_EXISTS(ErrorCode.CONFLICT, "존재하는 사용자 아이디 입니다.", LogLevel.WARN),
+    NEW_PASSWORD_MISMATCH(ErrorCode.BAD_REQUEST, "새 비밀번호가 일치하지 않습니다.", LogLevel.WARN),
+
+    FIELD_ERROR_DEFAULT(ErrorCode.BAD_REQUEST,"유효성 검사 오류입니다.", LogLevel.WARN),
+    INTERNAL_SERVER_ERROR(ErrorCode.INTERNAL_SERVER_ERROR,"서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", LogLevel.ERROR),
+
+    DEPARTMENT_NOT_FOUND(ErrorCode.NOT_FOUND, "부서를 찾을 수 없습니다.", LogLevel.WARN),
+
+    ;
+    private final ErrorCode code;
+    private final String message;
+    private final LogLevel logLevel;
+}

--- a/src/main/java/com/example/bookmanagementsystembo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/bookmanagementsystembo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,69 @@
+package com.example.bookmanagementsystembo.exception;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+//@Hidden
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * CoreException을 처리하는 메서드
+     */
+    @ExceptionHandler(CoreException.class)
+    public ResponseEntity<ErrorResponse> handleCoreException(CoreException coreException) {
+        logError(coreException.getErrorType());
+        ErrorResponse errorResponse = ErrorResponse.of(
+                coreException.getErrorType().getCode().getMessage(),
+                coreException.getErrorType().getMessage(),
+                coreException.getPayload()
+        );
+        return ResponseEntity.status(coreException.getErrorType().getCode().getStatus()).body(errorResponse);
+    }
+
+    /**
+     * 요청 데이터 검증 실패시 처리하는 메서드
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, @NonNull HttpHeaders headers, @NonNull HttpStatusCode status, @NonNull WebRequest request) {
+        logError(ErrorType.FIELD_ERROR_DEFAULT);
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        String errorMessage = (fieldError != null) ? fieldError.getDefaultMessage() : ErrorType.FIELD_ERROR_DEFAULT.getMessage();
+
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.BAD_REQUEST.getMessage(), errorMessage);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * 그 외의 모든 예외를 처리하는 메서드
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAllExceptions(Exception exception) {
+        logError(ErrorType.INTERNAL_SERVER_ERROR);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(), exception.getMessage());
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).body(errorResponse);
+    }
+
+
+    private void logError(ErrorType errorType) {
+        LogLevel logLevel = errorType.getLogLevel();
+        switch (logLevel) {
+            case WARN -> log.warn(errorType.getMessage());
+            case ERROR -> log.error(errorType.getMessage());
+            default -> log.info(errorType.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
도입 배경:
- 예외 처리/응답 포맷/로깅이 서비스별로 달라 일관성 부족
- CoreException + GlobalExceptionHandler로 상태코드/메시지/로그 레벨 표준화

작업 내용:
- 전역 @RestControllerAdvice 추가하여 Spring 표준 예외 및 CoreException → 공통 응답으로 매핑