### PR TITLE
feat: JWT 인증을 위한 이메일 기반 CustomUserDetailsService 구현

### DIFF
--- a/src/main/java/com/example/bookmanagementsystembo/user/domain/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/bookmanagementsystembo/user/domain/service/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.example.bookmanagementsystembo.user.domain.service;
+
+import com.example.bookmanagementsystembo.user.domain.entity.Users;
+import com.example.bookmanagementsystembo.user.infra.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Users user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())       // email을 username처럼 사용
+                .password(user.getPassword())
+                .roles(user.getRole().name())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/bookmanagementsystembo/user/infra/UserRepository.java
+++ b/src/main/java/com/example/bookmanagementsystembo/user/infra/UserRepository.java
@@ -3,8 +3,11 @@ package com.example.bookmanagementsystembo.user.infra;
 import com.example.bookmanagementsystembo.user.domain.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<Users, Long> {
 
     boolean existsByEmail(String email);
 
+    Optional<Users> findByEmail(String email);
 }


### PR DESCRIPTION
작업 내용:
- `CustomUserDetailsService` 구현
- `UserDetailsService` 인터페이스의 `loadUserByUsername` 메서드를 오버라이드하여 이메일 기반 사용자 조회 로직 추가
